### PR TITLE
Fix project description state issue

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/cart/CartSummary/CartSummary.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartSummary/CartSummary.tsx
@@ -13,7 +13,7 @@ import {
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { teamSizeSelector } from "slices/event/teamSlice";
 import { isTestUserSelector } from "slices/users/userSlice";
-import { projectDescriptionSelector } from "slices/event/teamDetailSlice";
+import { projectDescriptionSelector } from "slices/event/teamSlice";
 import {
     hardwareSignOutEndDate,
     hardwareSignOutStartDate,

--- a/hackathon_site/dashboard/frontend/src/components/teamDetail/ProjectDescription/ProjectDescriptionDetail.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/teamDetail/ProjectDescription/ProjectDescriptionDetail.tsx
@@ -1,14 +1,13 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import {
-    projectDescriptionSelector,
-    isTeamInfoLoadingSelector,
-} from "slices/event/teamDetailSlice";
+import { isTeamInfoLoadingSelector } from "slices/event/teamDetailSlice";
+import { projectDescriptionSelector } from "slices/event/teamSlice";
 import styles from "./ProjectDescription.module.scss";
 import { LinearProgress, Paper, Typography } from "@material-ui/core";
 
 const ProjectDescriptionDetail = () => {
     const projectDescription = useSelector(projectDescriptionSelector);
+    // TODO: move project description redux logic to teamSlice
     const isTeamInfoLoading = useSelector(isTeamInfoLoadingSelector);
 
     return (

--- a/hackathon_site/dashboard/frontend/src/slices/event/teamSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/event/teamSlice.ts
@@ -16,6 +16,7 @@ interface TeamExtraState {
     isJoinTeamLoading: boolean;
     error: string | null;
     team: Team | null;
+    projectDescription: string | null;
 }
 
 export const initialState: TeamExtraState = {
@@ -24,6 +25,7 @@ export const initialState: TeamExtraState = {
     isJoinTeamLoading: false,
     error: null,
     team: null,
+    projectDescription: null,
 };
 
 export const teamReducerName = "participantTeam";
@@ -152,6 +154,7 @@ const teamSlice = createSlice({
                     state.isLoading = false;
                     state.error = null;
                     state.team = payload;
+                    state.projectDescription = payload.project_description;
                 }
             }
         );
@@ -171,6 +174,7 @@ const teamSlice = createSlice({
                 state.isLeaveTeamLoading = false;
                 state.error = null;
                 state.team = payload;
+                state.projectDescription = payload.project_description;
             }
         );
 
@@ -190,6 +194,7 @@ const teamSlice = createSlice({
                 state.isJoinTeamLoading = false;
                 state.error = null;
                 state.team = payload;
+                state.projectDescription = payload.project_description;
             }
         );
 
@@ -241,4 +246,9 @@ export const teamMemberNamesSelector = createSelector(
 export const teamSizeSelector = createSelector(
     [teamSliceSelector],
     (teamSlice) => teamSlice.team?.profiles?.length ?? 0
+);
+
+export const projectDescriptionSelector = createSelector(
+    [teamSliceSelector],
+    (teamSlice) => teamSlice.projectDescription
 );


### PR DESCRIPTION
## Overview

- Bug: When user refreshed the page and tried to submit orders, the button was disabled.
- Fix: Added state logic so it would fetch project description in Cart Page so it wouldn't be disabled


## Unit Tests Created

- ignore failing test cases for now


## Steps to QA

- make sure you can submit orders normally so no alerts(like too little project description in Cart page), refresh the page and you should still be able to 
